### PR TITLE
Remove markdown extension

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,13 @@
 # This is the official list of <PROJECT> authors for copyright purposes.
 # This file is distinct from the CONTRIBUTORS files
 # and it lists the copyright holders only.
- 
+
 # Names should be added to this file as one of
 # Organization's name
 # Individual's name <submission email address>
 # Individual's name <submission email address> <email2> <emailN>
 # See CONTRIBUTORS for the meaning of multiple email addresses.
- 
+
 # Please keep the list sorted.
- 
+
 OVH SAS

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,5 +12,5 @@
 # Please keep the list sorted.
 #
 
-* **[Kevin Georges](https://github.com/d33d33)**
-* **[Aurélien Hébert](https://github.com/aurrelhebert)**
+Kevin Georges <https://github.com/d33d33>
+Aurélien Hébert <https://github.com/aurrelhebert>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,5 +10,5 @@
 # Please keep the list sorted.
 #
 
-* **[Kevin Georges](https://github.com/d33d33)**
-* **[Aurélien Hébert](https://github.com/aurrelhebert)**
+Kevin Georges <https://github.com/d33d33>
+Aurélien Hébert <https://github.com/aurrelhebert>


### PR DESCRIPTION
Prevent render `AUTHORS`, `CONTRIBUTORS` and `MAINTAINERS` as a markdown file.

Signed-off-by: Antoine Leblanc <antoine.leblanc@corp.ovh.com>